### PR TITLE
Add pytest-based tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,13 @@ Rigistrasse 3, 6300, Zug, Switzerland.
 * GUI frontend for Python script. Currently for Mac only https://github.com/lehenbauer/unmixer (by @lehenbauer)
 
 
+
+### Running tests
+
+The project uses [pytest](https://pytest.org) for its test suite. To run the tests, execute:
+
+```bash
+pytest
+```
+
+This command will discover and run all tests in the `tests/` directory.

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,34 @@
+import pytest
+from tools.api.lalalai_splitter import make_content_disposition, get_filename_from_content_disposition
+
+
+def test_make_content_disposition_ascii():
+    header = make_content_disposition("file.txt")
+    assert header == 'attachment; filename="file.txt"'
+
+
+def test_make_content_disposition_unicode():
+    name = 'файл.txt'
+    header = make_content_disposition(name)
+    assert header.startswith('attachment; filename*=utf-8\'\'')
+    # Check that encoded part matches quoted
+    encoded_part = header.split("''", 1)[1]
+    from urllib.parse import unquote
+    assert unquote(encoded_part) == name
+
+
+def test_get_filename_from_content_disposition_ascii():
+    header = 'attachment; filename="test.txt"'
+    assert get_filename_from_content_disposition(header) == 'test.txt'
+
+
+def test_get_filename_from_content_disposition_unicode():
+    name = 'пример.txt'
+    from urllib.parse import quote
+    header = f"attachment; filename*=utf-8''{quote(name)}"
+    assert get_filename_from_content_disposition(header) == name
+
+
+def test_get_filename_from_content_disposition_invalid():
+    with pytest.raises(ValueError):
+        get_filename_from_content_disposition('attachment')


### PR DESCRIPTION
## Summary
- set up `tests/` with pytest
- add unit tests for `make_content_disposition` and `get_filename_from_content_disposition`
- document running tests in `readme.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a253f0a08330b50133f1578dbed8