### PR TITLE
Add Flask web app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,14 @@ Rigistrasse 3, 6300, Zug, Switzerland.
 * GUI frontend for Python script. Currently for Mac only https://github.com/lehenbauer/unmixer (by @lehenbauer)
 
 
+
+### Running the Flask Web App
+
+A lightweight web interface is available in the `webapp/` directory. Install the required packages and start the server:
+
+```bash
+pip install flask yt_dlp
+python webapp/app.py
+```
+
+Then open `http://127.0.0.1:5000` in your browser.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,100 @@
+from flask import Flask, render_template, request, redirect, url_for
+from tools.api import lalalai_splitter
+from yt_dlp import YoutubeDL
+import os
+import tempfile
+
+app = Flask(__name__)
+
+
+def search_youtube(query, max_results=5, search_type='video'):
+    ydl_opts = {
+        'quiet': True,
+        'skip_download': True,
+        'extract_flat': 'in_playlist',
+    }
+    results = []
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(f"ytsearch{max_results}:{query}", download=False)
+        for entry in info.get('entries', []):
+            if search_type == 'playlist' and entry.get('_type') != 'playlist':
+                continue
+            if search_type == 'video' and entry.get('_type') == 'playlist':
+                continue
+            results.append({'title': entry.get('title'), 'url': entry.get('url') or entry.get('webpage_url')})
+    return results
+
+
+def download_audio(url):
+    temp_dir = tempfile.mkdtemp()
+    ydl_opts = {
+        'quiet': True,
+        'format': 'bestaudio/best',
+        'outtmpl': os.path.join(temp_dir, '%(id)s.%(ext)s'),
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        file_path = ydl.prepare_filename(info)
+    return file_path, temp_dir
+
+
+def convert_file(path, license_key, stem='vocals', filter_type=1, splitter='phoenix'):
+    output_dir = tempfile.mkdtemp()
+    lalalai_splitter.batch_process_for_file(license_key, path, output_dir, stem, filter_type, splitter)
+    files = [os.path.join(output_dir, f) for f in os.listdir(output_dir)]
+    return files
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/search', methods=['GET', 'POST'])
+def search():
+    results = []
+    if request.method == 'POST':
+        query = request.form.get('query')
+        if query:
+            results = search_youtube(query)
+    return render_template('search.html', results=results)
+
+
+@app.route('/search_playlist', methods=['GET', 'POST'])
+def search_playlist():
+    results = []
+    if request.method == 'POST':
+        query = request.form.get('query')
+        if query:
+            results = search_youtube(query, search_type='playlist')
+    return render_template('search_playlist.html', results=results)
+
+
+@app.route('/convert_song', methods=['GET', 'POST'])
+def convert_song():
+    results = []
+    if request.method == 'POST':
+        url = request.form.get('url')
+        license_key = request.form.get('license')
+        if url and license_key:
+            file_path, _ = download_audio(url)
+            results = convert_file(file_path, license_key)
+    return render_template('convert_song.html', results=results)
+
+
+@app.route('/convert_playlist', methods=['GET', 'POST'])
+def convert_playlist():
+    results = []
+    if request.method == 'POST':
+        url = request.form.get('url')
+        license_key = request.form.get('license')
+        if url and license_key:
+            videos = search_youtube(url, search_type='video')
+            for video in videos:
+                file_path, _ = download_audio(video['url'])
+                results.extend(convert_file(file_path, license_key))
+    return render_template('convert_playlist.html', results=results)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <title>LALAL.AI Web App</title>
+</head>
+<body>
+  <nav>
+    <a href="{{ url_for('search') }}">Search by Song</a> |
+    <a href="{{ url_for('search_playlist') }}">Search Playlist</a> |
+    <a href="{{ url_for('convert_playlist') }}">Convert Playlist to Acapella</a> |
+    <a href="{{ url_for('convert_song') }}">Convert Song to Acapella</a>
+  </nav>
+  <hr>
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/webapp/templates/convert_playlist.html
+++ b/webapp/templates/convert_playlist.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Convert Playlist to Acapella</h1>
+<form method="post">
+  <input type="text" name="url" placeholder="Playlist URL or search term">
+  <input type="text" name="license" placeholder="License key">
+  <button type="submit">Convert</button>
+</form>
+{% if results %}
+<ul>
+  {% for r in results %}
+  <li>{{ r }}<br>
+    <video width="320" controls>
+      <source src="{{ r }}">
+    </video>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/webapp/templates/convert_song.html
+++ b/webapp/templates/convert_song.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Convert Song to Acapella</h1>
+<form method="post">
+  <input type="text" name="url" placeholder="Song URL">
+  <input type="text" name="license" placeholder="License key">
+  <button type="submit">Convert</button>
+</form>
+{% if results %}
+<ul>
+  {% for r in results %}
+  <li>{{ r }}<br>
+    <video width="320" controls>
+      <source src="{{ r }}">
+    </video>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Welcome to LALAL.AI Web App</h1>
+<p>Use the navigation links above to interact with the API.</p>
+{% endblock %}

--- a/webapp/templates/search.html
+++ b/webapp/templates/search.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Search by Song</h1>
+<form method="post">
+  <input type="text" name="query" placeholder="Song name">
+  <button type="submit">Search</button>
+</form>
+{% if results %}
+<ul>
+  {% for r in results %}
+  <li>{{ r.title }}<br>
+    <video width="320" controls>
+      <source src="{{ r.url }}">
+    </video>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/webapp/templates/search_playlist.html
+++ b/webapp/templates/search_playlist.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Search Playlist</h1>
+<form method="post">
+  <input type="text" name="query" placeholder="Playlist name">
+  <button type="submit">Search</button>
+</form>
+{% if results %}
+<ul>
+  {% for r in results %}
+  <li>{{ r.title }}<br>
+    <video width="320" controls>
+      <source src="{{ r.url }}">
+    </video>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a simple Flask application with four main routes
- include HTML templates with a navigation bar
- document how to start the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a22c38948330809f09c9eb3b96cc